### PR TITLE
Changes for cross-tenant integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To execute the Terraform script:
 
 ```
 module "iam-config" {
-  source     = "github.com/uptycslabs/terraform-azurearm-ad-config"
+  source     = "github.com/uptycslabs/terraform-azurerm-ad-config"
 
   # modify as you need
   resource_prefix = "uptycs-cloudquery-integration-123"

--- a/README.md
+++ b/README.md
@@ -64,10 +64,17 @@ To execute the Terraform script:
 
 ```
 module "iam-config" {
-  source     = "github.com/uptycslabs/terraform-azure-iam-config"
+  source     = "github.com/uptycslabs/terraform-azurearm-ad-config"
 
   # modify as you need
   resource_prefix = "uptycs-cloudquery-integration-123"
+  
+  # Find the client_id on Azure Integration page of Uptycs Web
+  uptycs_app_client_id = "Client ID from Azure Integration page"
+  
+  # If you are integrating a subscription for the first time, set the value to false. 
+  # For the second or multiple subscription integrations in the same tenant, set the value to true.
+  use_existing_service_principal = false
 }
 
 output "subscription_id" {
@@ -86,7 +93,9 @@ output "subscription_name" {
 
 | Name            | Description                                | Type     | Default                             |
 | ----------------- | -------------------------------------------- | ---------- | ------------------------------------- |
-| resource_prefix | Prefix to be used for naming new resources | `string` | `uptycs-cloudquery-integration-123` |
+| resource_prefix | Prefix to be used for naming new resources | `string` | `uptycs-integration-123` |
+| uptycs_app_client_id | The Client ID of Uptycs Multi-tenant app | `string` | required |
+| use_existing_service_principal | Whether to create a new service princial or use existing one | `boolean` | required |
 
 **Outputs**
 
@@ -97,8 +106,8 @@ output "subscription_name" {
 | subscription_name | Name of the the azure subscription  |
 
 ```sh
-$ terraform init
+$ terraform init --upgrade
 $ terraform plan # Please verify before applying
 $ terraform apply
-# Once terraform is applied successfully, it will create "client_credentials.json" file.
+# Wait until successfully completed
 ```

--- a/data.tf
+++ b/data.tf
@@ -5,4 +5,4 @@ data "azurerm_resources" "Fetch_keyvalutids" {
   type = "Microsoft.KeyVault/vaults"
 }
 
-data "azuread_application_published_app_ids" "app_ids" {}
+data "azuread_application_published_app_ids" "well_known" {}

--- a/main.tf
+++ b/main.tf
@@ -1,97 +1,75 @@
+# Get MSGraph App
 resource "azuread_service_principal" "msgraph" {
-  application_id = data.azuread_application_published_app_ids.app_ids.result.MicrosoftGraph
+  application_id = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
   use_existing   = true
 }
 
-resource "azuread_application" "application_registration" {
-  display_name = "${var.resource_prefix}"
-  required_resource_access {
-    resource_app_id = data.azuread_application_published_app_ids.app_ids.result.MicrosoftGraph
-    resource_access {
-      id   = azuread_service_principal.msgraph.app_role_ids["Group.Read.All"]
-      type = "Role"
-    }
-
-    resource_access {
-      id   = azuread_service_principal.msgraph.app_role_ids["User.Read.All"]
-      type = "Role"
-    }
-
-    resource_access {
-      id   = azuread_service_principal.msgraph.app_role_ids["Directory.Read.All"]
-      type = "Role"
-    }
-
-    resource_access {
-      id   = azuread_service_principal.msgraph.app_role_ids["OnPremisesPublishingProfiles.ReadWrite.All"]
-      type = "Role"
-    }
-
-    resource_access {
-      id   = azuread_service_principal.msgraph.app_role_ids["Application.Read.All"]
-      type = "Role"
-    }
-
-
-
-  }
+# Create a service principal for the Uptycs App 
+resource "azuread_service_principal" "service_principal" {
+  application_id = var.uptycs_app_client_id
+  use_existing   = true
 }
 
-resource "azuread_app_role_assignment" "UserReadAll" {
-  app_role_id         = azuread_service_principal.msgraph.app_role_ids["User.Read.All"]
-  principal_object_id = azuread_service_principal.serviceprincipal.object_id
-  resource_object_id  = azuread_service_principal.msgraph.object_id
-}
-
-resource "azuread_app_role_assignment" "DirectoryReadAll" {
-  app_role_id         = azuread_service_principal.msgraph.app_role_ids["Directory.Read.All"]
-  principal_object_id = azuread_service_principal.serviceprincipal.object_id
-  resource_object_id  = azuread_service_principal.msgraph.object_id
-}
-
-resource "azuread_app_role_assignment" "ApplicationReadAll" {
+# Create Graph API related permissions to the service principal
+resource "azuread_app_role_assignment" "application_reader_role" {
+  count = var.use_existing_service_principal ? 0 : 1
   app_role_id         = azuread_service_principal.msgraph.app_role_ids["Application.Read.All"]
-  principal_object_id = azuread_service_principal.serviceprincipal.object_id
+  principal_object_id = azuread_service_principal.service_principal.object_id
   resource_object_id  = azuread_service_principal.msgraph.object_id
 }
 
-resource "azuread_app_role_assignment" "OnPremisesPublishingProfilesReadWriteAll" {
-  app_role_id         = azuread_service_principal.msgraph.app_role_ids["OnPremisesPublishingProfiles.ReadWrite.All"]
-  principal_object_id = azuread_service_principal.serviceprincipal.object_id
+resource "azuread_app_role_assignment" "user_reader_role" {
+  count = var.use_existing_service_principal ? 0 : 1
+  app_role_id         = azuread_service_principal.msgraph.app_role_ids["User.Read.All"]
+  principal_object_id = azuread_service_principal.service_principal.object_id
   resource_object_id  = azuread_service_principal.msgraph.object_id
 }
 
-resource "azuread_app_role_assignment" "GroupReadAll" {
+resource "azuread_app_role_assignment" "directory_reader_role" {
+  count = var.use_existing_service_principal ? 0 : 1
+  app_role_id         = azuread_service_principal.msgraph.app_role_ids["Directory.Read.All"]
+  principal_object_id = azuread_service_principal.service_principal.object_id
+  resource_object_id  = azuread_service_principal.msgraph.object_id
+}
+
+resource "azuread_app_role_assignment" "organization_reader_role" {
+  count = var.use_existing_service_principal ? 0 : 1
+  app_role_id         = azuread_service_principal.msgraph.app_role_ids["Organization.Read.All"]
+  principal_object_id = azuread_service_principal.service_principal.object_id
+  resource_object_id  = azuread_service_principal.msgraph.object_id
+}
+
+resource "azuread_app_role_assignment" "group_reader_role" {
+  count = var.use_existing_service_principal ? 0 : 1
   app_role_id         = azuread_service_principal.msgraph.app_role_ids["Group.Read.All"]
-  principal_object_id = azuread_service_principal.serviceprincipal.object_id
+  principal_object_id = azuread_service_principal.service_principal.object_id
   resource_object_id  = azuread_service_principal.msgraph.object_id
 }
 
-resource "azuread_service_principal" "serviceprincipal" {
-  application_id = azuread_application.application_registration.application_id
-}
-resource "azuread_application_password" "password_generation" {
-  application_object_id = azuread_application.application_registration.object_id
-  end_date_relative     = "43200h"
-  display_name          = "cloudquery"
+resource "azuread_app_role_assignment" "on_premises_publishing_profiles_reader_role" {
+  count = var.use_existing_service_principal ? 0 : 1
+  app_role_id         = azuread_service_principal.msgraph.app_role_ids["OnPremisesPublishingProfiles.ReadWrite.All"]
+  principal_object_id = azuread_service_principal.service_principal.object_id
+  resource_object_id  = azuread_service_principal.msgraph.object_id
 }
 
-resource "azurerm_role_assignment" "Attach_Readerrole" {
+# Give the service principal a Reader role in the Subscription
+resource "azurerm_role_assignment" "attach_reader_role" {
+  principal_id         = azuread_service_principal.service_principal.id
   scope                = data.azurerm_subscription.primary.id
   role_definition_name = "Reader"
-  principal_id         = azuread_service_principal.serviceprincipal.id
 }
 
 resource "azurerm_role_assignment" "Attach_Key_Vault_Readerrole" {
   scope                = data.azurerm_subscription.primary.id
   role_definition_name = "Key Vault Reader"
-  principal_id         = azuread_service_principal.serviceprincipal.id
+  principal_id         = azuread_service_principal.service_principal.id
 }
 
 resource "azurerm_role_assignment" "Attach_StorageAccountKeyOperatorServicerole" {
   scope                = data.azurerm_subscription.primary.id
   role_definition_name = "Storage Account Key Operator Service Role"
-  principal_id         = azuread_service_principal.serviceprincipal.id
+  principal_id         = azuread_service_principal.service_principal.id
 }
 
 resource "azurerm_role_definition" "Define_App_Service_Auth_Reader" {
@@ -113,7 +91,7 @@ resource "azurerm_role_definition" "Define_App_Service_Auth_Reader" {
 resource "azurerm_role_assignment" "Attach_App_Service_Auth_Reader" {
   scope              = data.azurerm_subscription.primary.id
   role_definition_id = azurerm_role_definition.Define_App_Service_Auth_Reader.role_definition_resource_id
-  principal_id       = azuread_service_principal.serviceprincipal.id
+  principal_id       = azuread_service_principal.service_principal.id
 }
 
 
@@ -121,7 +99,7 @@ resource "azurerm_key_vault_access_policy" "attach_keyvalut_policy" {
   count        = length(data.azurerm_resources.Fetch_keyvalutids.resources)
   key_vault_id = data.azurerm_resources.Fetch_keyvalutids.resources[count.index].id
   tenant_id    = data.azurerm_subscription.primary.tenant_id
-  object_id    = azuread_service_principal.serviceprincipal.object_id
+  object_id    = azuread_service_principal.service_principal.object_id
 
   key_permissions = []
 
@@ -129,21 +107,4 @@ resource "azurerm_key_vault_access_policy" "attach_keyvalut_policy" {
     "List",
   ]
   storage_permissions = []
-}
-
-
-resource "local_file" "Credentails" {
-  content = jsonencode({
-    "clientId"                       = "${azuread_application.application_registration.application_id}",
-    "clientSecret"                   = "${azuread_application_password.password_generation.value}",
-    "subscriptionId"                 = "${data.azurerm_subscription.primary.subscription_id}",
-    "tenantId"                       = "${data.azurerm_subscription.primary.tenant_id}",
-    "activeDirectoryEndpointUrl"     = "https://login.microsoftonline.com",
-    "resourceManagerEndpointUrl"     = "https://management.azure.com/",
-    "activeDirectoryGraphResourceId" = "https://graph.windows.net/",
-    "sqlManagementEndpointUrl"       = "https://management.core.windows.net=8443/",
-    "galleryEndpointUrl"             = "https://gallery.azure.com/",
-    "managementEndpointUrl"          = "https://management.core.windows.net/"
-  })
-  filename = "client_credentials.json"
 }

--- a/providers.tf
+++ b/providers.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 2.72.0"
+      version = ">= 3.39.1"
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = ">= 1.6.0"
+      version = ">= 2.32.0"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,15 @@
 variable "resource_prefix" {
   description = "Pass prefix to identify Application and resources"
   type        = string
-  default     = "uptycs-cloudquery-integration-123"
+  default     = "uptycs-integration-123"
+}
+
+variable "uptycs_app_client_id" {
+  description = "Client ID of Uptycs Multitenant App"
+  type = string
+}
+
+variable "use_existing_service_principal" {
+  description = "If you are integrating a subscription for the first time, set the value to false. For the second or other subscription integrations in the same tenant, set the value to true."
+  type = bool
 }


### PR DESCRIPTION
New changes do the following:
- Create a service principal for multi-tenant Uptycs App instead of app registration
- Create role assignments for the service principal
- Add the service principal as a Reader to the Subscription IAM