### PR TITLE
CSM-8882: Azure subscription terraform : source code is pointing to github instead of terraform registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ To execute the Terraform script:
 
 ```
 module "iam-config" {
-  source     = "github.com/uptycslabs/terraform-azurerm-ad-config"
+  source     = "uptycslabs/ad-config/azurerm"
 
   # modify as you need
   resource_prefix = "uptycs-cloudquery-integration-123"


### PR DESCRIPTION
Changed the source in readme from git repository to terraform registry

**TestCase:**

- [x] Run the terraform with git repository as source and change source to registry run terraform no configuration should change

- [x] Destroy earlier terraform and run with source as registry it should work