### PR TITLE
CSM-4025: added new permission Policy.Read.All

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ It creates the following resources:
   - OnPremisesPublishingProfiles.ReadWrite.All
   - Organization.Read.All
   - AuditLog.Read.All
+  - Policy.Read.All
 
   **Policies**:
 

--- a/main.tf
+++ b/main.tf
@@ -60,6 +60,13 @@ resource "azuread_app_role_assignment" "audit_log_reader_role" {
   resource_object_id  = azuread_service_principal.msgraph.object_id
 }
 
+resource "azuread_app_role_assignment" "policy_reader_role" {
+  count = var.use_existing_service_principal ? 0 : 1
+  app_role_id         = azuread_service_principal.msgraph.app_role_ids["Policy.Read.All"]
+  principal_object_id = azuread_service_principal.service_principal.object_id
+  resource_object_id  = azuread_service_principal.msgraph.object_id
+}
+
 # Give the service principal a Reader role in the Subscription
 resource "azurerm_role_assignment" "attach_reader_role" {
   principal_id         = azuread_service_principal.service_principal.id


### PR DESCRIPTION
Added permission [Policy.Read.All]

TestCase:

- [x] run terraform with changes, `Policy.Read.All` should be attached to the application
- [x] destroy existing terraform and run with old version and change the source with latest changes and apply again we should n't get anny errors and new perssion should be attched
- [x] run terraform in another subscription with `use_existing_service_principal` it should not fail