### PR TITLE
CSM-13647: Updating Readme to permission requirements for Subscription Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ Ensure you have the following privileges before you execute the Terraform Script
   - `Application Administrator` (AD Role)
 - `Owner` role at the subscription scope which is being integrated
 
-Absence of the above privileges may result in Access related issues when trying to run the Terraform.
+Absence of the above privileges may result in access related issues when trying to run the Terraform.
 
 ## What does the Terraform do?
 
-Terraform is going to create a new **Service Principal** corresponding to our Multi-Tenant App Registration and assign below Roles/Permissions/Policies to it at the scope of the Subscription which is being integrated. Uptycs requires these set of Roles/Permissions to be able to fetch the required information from your Tenant:
+Running the Terraform creates a new **Service Principal** corresponding to Uptycs's Multi-Tenant App Registration. It assigns below Roles/Permissions/Policies at the scope of the Subscription which is being integrated. Uptycs requires these set of Roles/Permissions to be able to fetch the required information from your Tenant:
 
 **Roles**:
 
@@ -90,9 +90,7 @@ output "subscription_name" {
 }
 ```
 
-### Step-2: Terraform Init, Plan and Apply
-
-**Inputs**
+Specify the following parameters in the Terraform file:
 
 | Name                           | Description                                                  | Type      | Default                  |
 | ------------------------------ | ------------------------------------------------------------ | --------- | ------------------------ |
@@ -101,6 +99,8 @@ output "subscription_name" {
 | use_existing_service_principal | Whether to create a new service princial or use existing one | `boolean` | required                 |
 
 **IMPORTANT NOTE:** If you have already integrated another subscription individually from the same Azure Tenant, then change the value of `use_existing_service_principal` to `true` in the above Terraform script before executing it. The Terraform will re-use the same Service Principal in that case.
+
+### Step-2: Terraform Init, Plan and Apply
 
 Execute the below commands in your terminal:
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ $ az account set --subscription="SUBSCRIPTION_ID"
 
 To execute the Terraform script:
 
-### 1. Prepare .tf file
+### Step-1: Prepare .tf file
 
 Create a `main.tf` file in a new folder. Copy and paste the following configuration and modify as required:
 
@@ -90,7 +90,7 @@ output "subscription_name" {
 }
 ```
 
-### 2. Init, Plan and Apply
+### Step-2: Terraform Init, Plan and Apply
 
 **Inputs**
 
@@ -111,7 +111,7 @@ $ terraform apply
 # Wait until successfully completed
 ```
 
-### 3. Outputs
+### Step-3: Outputs
 
 After running the Terraform, the following outputs are generated, which you need to add in the Uptycs Integration Page along with your Azure Tenant ID:
 

--- a/README.md
+++ b/README.md
@@ -11,12 +11,11 @@ Ensure you have the following privileges before you execute the Terraform Script
   - `Application Administrator` (AD Role)
 - `Owner` role at the subscription scope which is being integrated
 
-Absence of the above privileges will result in Access related issues when trying to run the Terraform.
+Absence of the above privileges may result in Access related issues when trying to run the Terraform.
 
 ## What does the Terraform do?
 
-Terraform is going to create a new <u>**Service Principal**</u> corresponding to our Multi-Tenant App Registration and assign below Roles/Permissions/Policies to it at the scope of the Subscription which is being integrated. Uptycs requires these set of Roles/Permissions to be able to fetch the required information from your Tenant:
-It creates the following resources:
+Terraform is going to create a new **Service Principal** corresponding to our Multi-Tenant App Registration and assign below Roles/Permissions/Policies to it at the scope of the Subscription which is being integrated. Uptycs requires these set of Roles/Permissions to be able to fetch the required information from your Tenant:
 
 **Roles**:
 
@@ -37,7 +36,7 @@ It creates the following resources:
 - UserAuthenticationMethod.Read.All
 - Policy.Read.All
 
-**Policies**:
+**Policy**:
 
 - Key Vault Access Policy (certificate_permissions : List, Get)
 
@@ -103,6 +102,8 @@ output "subscription_name" {
 
 **IMPORTANT NOTE:** If you have already integrated another subscription individually from the same Azure Tenant, then change the value of `use_existing_service_principal` to `true` in the above Terraform script before executing it. The Terraform will re-use the same Service Principal in that case.
 
+Execute the below commands in your terminal:
+
 ```sh
 $ terraform init --upgrade
 $ terraform plan # Please verify before applying
@@ -111,6 +112,8 @@ $ terraform apply
 ```
 
 ### 3. Outputs
+
+After running the Terraform, the following outputs are generated, which you need to add in the Uptycs Integration Page along with your Azure Tenant ID:
 
 | Name              | Description                          |
 | ----------------- | ------------------------------------ |

--- a/README.md
+++ b/README.md
@@ -2,43 +2,44 @@
 
 This module provides the required Azure resources to integrate an Azure subscription with Uptycs.
 
-
-It creates the following resources:
-
-* Application
-* Service principal to the application
-* It attaches the following roles and permissions to the service principal:
-
-  **Roles**:
-
-  - Reader
-  - Key Vault Reader
-  - Storage Blob Data Reader
-  - Storage Account Key Operator Service Role
-  - Custom read-only access for required resources
-
-  **API permissions**:
-
-  - Directory.Read.All
-  - User.Read.All
-  - Group.Read.All
-  - Application.Read.All
-  - OnPremisesPublishingProfiles.ReadWrite.All
-  - Organization.Read.All
-  - UserAuthenticationMethod.Read.All
-  - Policy.Read.All
-
-  **Policies**:
-
-  - Key Vault Access Policy (certificate_permissions : List, Get)
-
-## Prerequisites
+## Prerequisites [Do Not Skip]
 
 Ensure you have the following privileges before you execute the Terraform Script:
 
-* The user should have `owner` role in subscription to create resources
-* Administrative roles:
-  * Global administrator
+- Administrative roles:
+  - `Privileged Role Administrator` (AD Role)
+  - `Application Administrator` (AD Role)
+- `Owner` role at the subscription scope which is being integrated
+
+Absence of the above privileges will result in Access related issues when trying to run the Terraform.
+
+## What does the Terraform do?
+
+Terraform is going to create a new <u>**Service Principal**</u> corresponding to our Multi-Tenant App Registration and assign below Roles/Permissions/Policies to it at the scope of the Subscription which is being integrated. Uptycs requires these set of Roles/Permissions to be able to fetch the required information from your Tenant:
+It creates the following resources:
+
+**Roles**:
+
+- Reader
+- Key Vault Reader
+- Storage Blob Data Reader
+- Storage Account Key Operator Service Role
+- Custom read-only access for required resources
+
+**API permissions**:
+
+- Directory.Read.All
+- User.Read.All
+- Group.Read.All
+- Application.Read.All
+- OnPremisesPublishingProfiles.ReadWrite.All
+- Organization.Read.All
+- UserAuthenticationMethod.Read.All
+- Policy.Read.All
+
+**Policies**:
+
+- Key Vault Access Policy (certificate_permissions : List, Get)
 
 ## Authentication
 
@@ -62,9 +63,9 @@ $ az account set --subscription="SUBSCRIPTION_ID"
 
 To execute the Terraform script:
 
-1. **Prepare .tf file**
+### 1. Prepare .tf file
 
-   Create a `main.tf` file in a new folder. Copy and paste the following configuration and modify as required:
+Create a `main.tf` file in a new folder. Copy and paste the following configuration and modify as required:
 
 ```
 module "iam-config" {
@@ -72,11 +73,11 @@ module "iam-config" {
 
   # modify as you need
   resource_prefix = "uptycs-cloudquery-integration-123"
-  
+
   # Find the client_id on Azure Integration page of Uptycs Web
   uptycs_app_client_id = "Client ID from Azure Integration page"
-  
-  # If you are integrating a subscription for the first time, set the value to false. 
+
+  # If you are integrating a subscription for the first time, set the value to false.
   # For the second or multiple subscription integrations in the same tenant, set the value to true.
   use_existing_service_principal = false
 }
@@ -90,24 +91,17 @@ output "subscription_name" {
 }
 ```
 
-**Init, Plan and Apply**
+### 2. Init, Plan and Apply
 
 **Inputs**
 
+| Name                           | Description                                                  | Type      | Default                  |
+| ------------------------------ | ------------------------------------------------------------ | --------- | ------------------------ |
+| resource_prefix                | Prefix to be used for naming new resources                   | `string`  | `uptycs-integration-123` |
+| uptycs_app_client_id           | The Client ID of Uptycs Multi-tenant app                     | `string`  | required                 |
+| use_existing_service_principal | Whether to create a new service princial or use existing one | `boolean` | required                 |
 
-| Name            | Description                                | Type     | Default                             |
-| ----------------- | -------------------------------------------- | ---------- | ------------------------------------- |
-| resource_prefix | Prefix to be used for naming new resources | `string` | `uptycs-integration-123` |
-| uptycs_app_client_id | The Client ID of Uptycs Multi-tenant app | `string` | required |
-| use_existing_service_principal | Whether to create a new service princial or use existing one | `boolean` | required |
-
-**Outputs**
-
-
-| Name              | Description                         |
-| ------------------- | ------------------------------------- |
-| subscription_id   | Subscriptionid of the Azure Account |
-| subscription_name | Name of the the azure subscription  |
+**IMPORTANT NOTE:** If you have already integrated another subscription individually from the same Azure Tenant, then change the value of `use_existing_service_principal` to `true` in the above Terraform script before executing it. The Terraform will re-use the same Service Principal in that case.
 
 ```sh
 $ terraform init --upgrade
@@ -115,3 +109,10 @@ $ terraform plan # Please verify before applying
 $ terraform apply
 # Wait until successfully completed
 ```
+
+### 3. Outputs
+
+| Name              | Description                          |
+| ----------------- | ------------------------------------ |
+| subscription_id   | Subscription ID of the Azure Account |
+| subscription_name | Name of the the azure subscription   |


### PR DESCRIPTION
### Description
  * JIRA: https://uptycsjira.atlassian.net/browse/CSM-13647
  * CS JIRA: https://uptycsjira.atlassian.net/browse/CS-2691
  * As per the above CS ticket, we validated that we DO NOT need `Global Administrator` role for Individual Subscription Integration. A set of softened permissions, which are not as powerful as `Global Administrator`, are enough for the users to be able to start the integration procedure. Below are the set of roles a user need for tenant integration:
    * `Privileged Role Administrator` (AD Role)
    * `Application Administrator` (AD Role)
    * `Owner` Role over Root Management Group (RBAC Role)
  * Moved the Pre-requisite section to the top of the page to make sure that DOES NOT get skipped by the users.
  * Added better wording for what the Terraform is doing.
  * Added an Important Note section for the use of `use_existing_service_principal` boolean value to educate the users.
  * Added markdown enhancements to `Readme.md`.
  * Readme Preview in VSCode:
![Screenshot from 2023-11-22 14-15-43](https://github.com/uptycslabs/terraform-azurerm-ad-config/assets/93505703/8de466dd-0083-40a6-bd41-605dfb1a4d54)
![Screenshot from 2023-11-22 14-15-51](https://github.com/uptycslabs/terraform-azurerm-ad-config/assets/93505703/d13bde80-23cf-43c9-b71e-8de761615a7c)
