### PR TITLE
CSM-13935: Fix warnings that show up during Azure integration terraform

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,67 +1,67 @@
 # Get MSGraph App
 resource "azuread_service_principal" "msgraph" {
-  application_id = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
-  use_existing   = true
+  client_id    = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
+  use_existing = true
 }
 
 # Create a service principal for the Uptycs App 
 resource "azuread_service_principal" "service_principal" {
-  application_id = var.uptycs_app_client_id
-  use_existing   = true
+  client_id    = var.uptycs_app_client_id
+  use_existing = true
 }
 
 # Create Graph API related permissions to the service principal
 resource "azuread_app_role_assignment" "application_reader_role" {
-  count = var.use_existing_service_principal ? 0 : 1
+  count               = var.use_existing_service_principal ? 0 : 1
   app_role_id         = azuread_service_principal.msgraph.app_role_ids["Application.Read.All"]
   principal_object_id = azuread_service_principal.service_principal.object_id
   resource_object_id  = azuread_service_principal.msgraph.object_id
 }
 
 resource "azuread_app_role_assignment" "user_reader_role" {
-  count = var.use_existing_service_principal ? 0 : 1
+  count               = var.use_existing_service_principal ? 0 : 1
   app_role_id         = azuread_service_principal.msgraph.app_role_ids["User.Read.All"]
   principal_object_id = azuread_service_principal.service_principal.object_id
   resource_object_id  = azuread_service_principal.msgraph.object_id
 }
 
 resource "azuread_app_role_assignment" "directory_reader_role" {
-  count = var.use_existing_service_principal ? 0 : 1
+  count               = var.use_existing_service_principal ? 0 : 1
   app_role_id         = azuread_service_principal.msgraph.app_role_ids["Directory.Read.All"]
   principal_object_id = azuread_service_principal.service_principal.object_id
   resource_object_id  = azuread_service_principal.msgraph.object_id
 }
 
 resource "azuread_app_role_assignment" "organization_reader_role" {
-  count = var.use_existing_service_principal ? 0 : 1
+  count               = var.use_existing_service_principal ? 0 : 1
   app_role_id         = azuread_service_principal.msgraph.app_role_ids["Organization.Read.All"]
   principal_object_id = azuread_service_principal.service_principal.object_id
   resource_object_id  = azuread_service_principal.msgraph.object_id
 }
 
 resource "azuread_app_role_assignment" "group_reader_role" {
-  count = var.use_existing_service_principal ? 0 : 1
+  count               = var.use_existing_service_principal ? 0 : 1
   app_role_id         = azuread_service_principal.msgraph.app_role_ids["Group.Read.All"]
   principal_object_id = azuread_service_principal.service_principal.object_id
   resource_object_id  = azuread_service_principal.msgraph.object_id
 }
 
 resource "azuread_app_role_assignment" "on_premises_publishing_profiles_reader_role" {
-  count = var.use_existing_service_principal ? 0 : 1
+  count               = var.use_existing_service_principal ? 0 : 1
   app_role_id         = azuread_service_principal.msgraph.app_role_ids["OnPremisesPublishingProfiles.ReadWrite.All"]
   principal_object_id = azuread_service_principal.service_principal.object_id
   resource_object_id  = azuread_service_principal.msgraph.object_id
 }
 
 resource "azuread_app_role_assignment" "user_authentication_methods_reader_role" {
-  count = var.use_existing_service_principal ? 0 : 1
+  count               = var.use_existing_service_principal ? 0 : 1
   app_role_id         = azuread_service_principal.msgraph.app_role_ids["UserAuthenticationMethod.Read.All"]
   principal_object_id = azuread_service_principal.service_principal.object_id
   resource_object_id  = azuread_service_principal.msgraph.object_id
 }
 
 resource "azuread_app_role_assignment" "policy_reader_role" {
-  count = var.use_existing_service_principal ? 0 : 1
+  count               = var.use_existing_service_principal ? 0 : 1
   app_role_id         = azuread_service_principal.msgraph.app_role_ids["Policy.Read.All"]
   principal_object_id = azuread_service_principal.service_principal.object_id
   resource_object_id  = azuread_service_principal.msgraph.object_id

--- a/variables.tf
+++ b/variables.tf
@@ -6,10 +6,10 @@ variable "resource_prefix" {
 
 variable "uptycs_app_client_id" {
   description = "Client ID of Uptycs Multitenant App"
-  type = string
+  type        = string
 }
 
 variable "use_existing_service_principal" {
   description = "If you are integrating a subscription for the first time, set the value to false. For the second or other subscription integrations in the same tenant, set the value to true."
-  type = bool
+  type        = bool
 }


### PR DESCRIPTION
We are using one variable in azure ad provider. That is going to be depreciated in future. This varible name will be changed
We are hitting this warning
```
Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
╷
│ Warning: Argument is deprecated
│ 
│   with module.iam-config.azuread_service_principal.msgraph,
│   on .terraform/modules/iam-config/main.tf line 3, in resource "azuread_service_principal" "msgraph":
│    3:   application_id = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
│ 
│ The `application_id` property has been replaced with the `client_id` property and will be removed in version 3.0 of the AzureAD provider
│ 
│ (and one more similar warning elsewhere)
╵
```
Changed the variable name in our module

Test Cases:

- [x] Changed the variable in module run terraform apply. No warning
- [x] To test the regression re run the terraform after this change. No issue